### PR TITLE
Add Waiter Table Management page

### DIFF
--- a/src/ReserveMe/Domain/Domain.csproj
+++ b/src/ReserveMe/Domain/Domain.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+	<ProjectReference Include="..\Shared\Shared.csproj" />
     <ProjectReference Include="..\Common\Common.csproj" />
   </ItemGroup>
 

--- a/src/ReserveMe/Domain/Entities/Table.cs
+++ b/src/ReserveMe/Domain/Entities/Table.cs
@@ -1,17 +1,18 @@
-﻿namespace Domain.Entities
+﻿using Shared.Enums;
+
+
+namespace Domain.Entities
 {
-	public class Table
-	{
-		public int Id { get; set; }
-		public int VenueId { get; set; }
+    public class Table
+    {
+        public int Id { get; set; }
+        public int VenueId { get; set; }
+        public int TableNumber { get; set; }
+        public int Capacity { get; set; }
+        public TableStatus Status { get; set; } = TableStatus.Available;
+        public bool IsActive { get; set; } = true;
 
-		public int TableNumber { get; set; }
-
-		public int Capacity{ get; set; }
-
-		public bool IsActive { get; set; } = true;
-
-		// Navigation properties
-		public Venue Venue { get; set; }
-	}
+        // Navigation properties
+        public Venue Venue { get; set; }
+    }
 }

--- a/src/ReserveMe/ReserveMe.Server/Controllers/TablesController.cs
+++ b/src/ReserveMe/ReserveMe.Server/Controllers/TablesController.cs
@@ -1,0 +1,110 @@
+using Microsoft.AspNetCore.Mvc;
+using Shared.Dtos;
+using Shared.Enums;
+using ReserveMe.Server.Interfaces;
+
+namespace ReserveMe.Server.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class TablesController : ControllerBase
+    {
+        private readonly ITableService _tableService;
+
+        public TablesController(ITableService tableService)
+        {
+            _tableService = tableService;
+        }
+
+        [HttpGet("venue/{venueId:int}")]
+        public async Task<ActionResult<IEnumerable<TableDto>>> GetTablesByVenue(int venueId, [FromQuery] bool includeInactive = false)
+        {
+            var tables = await _tableService.GetTablesByVenueAsync(venueId, includeInactive);
+            return Ok(tables);
+        }
+
+        [HttpGet("{tableId:int}")]
+        public async Task<ActionResult<TableDto>> GetTable(int tableId)
+        {
+            var table = await _tableService.GetTableByIdAsync(tableId);
+            if (table == null) return NotFound();
+            return Ok(table);
+        }
+
+        [HttpGet("venue/{venueId:int}/statistics")]
+        public async Task<ActionResult<TableStatisticsDto>> GetStatistics(int venueId)
+        {
+            var stats = await _tableService.GetTableStatisticsAsync(venueId);
+            return Ok(stats);
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<TableDto>> CreateTable([FromBody] CreateTableDto dto)
+        {
+            try
+            {
+                var table = await _tableService.CreateTableAsync(dto);
+                return CreatedAtAction(nameof(GetTable), new { tableId = table.Id }, table);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(new { error = ex.Message });
+            }
+        }
+
+        [HttpPut("{tableId:int}")]
+        public async Task<ActionResult<TableDto>> UpdateTable(int tableId, [FromBody] UpdateTableDto dto)
+        {
+            var table = await _tableService.UpdateTableAsync(tableId, dto);
+            if (table == null) return NotFound();
+            return Ok(table);
+        }
+
+        [HttpPatch("{tableId:int}/status")]
+        public async Task<ActionResult<TableDto>> ChangeStatus(int tableId, [FromBody] ChangeTableStatusDto dto)
+        {
+            var table = await _tableService.ChangeTableStatusAsync(tableId, dto.Status);
+            if (table == null) return NotFound();
+            return Ok(table);
+        }
+
+        [HttpPost("{tableId:int}/release")]
+        public async Task<ActionResult<TableDto>> ReleaseTable(int tableId)
+        {
+            var table = await _tableService.ReleaseTableAsync(tableId);
+            if (table == null) return NotFound();
+            return Ok(table);
+        }
+
+        [HttpPost("{tableId:int}/seat")]
+        public async Task<ActionResult<TableDto>> SeatReservation(int tableId)
+        {
+            try
+            {
+                var table = await _tableService.SeatReservationAsync(tableId);
+                if (table == null) return NotFound();
+                return Ok(table);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(new { error = ex.Message });
+            }
+        }
+
+        [HttpPost("{tableId:int}/toggle-active")]
+        public async Task<ActionResult<TableDto>> ToggleActive(int tableId)
+        {
+            var table = await _tableService.ToggleTableActiveAsync(tableId);
+            if (table == null) return NotFound();
+            return Ok(table);
+        }
+
+        [HttpDelete("{tableId:int}")]
+        public async Task<ActionResult> DeleteTable(int tableId)
+        {
+            var result = await _tableService.DeleteTableAsync(tableId);
+            if (!result) return NotFound();
+            return NoContent();
+        }
+    }
+}

--- a/src/ReserveMe/ReserveMe.Server/Interfaces/ITableService.cs
+++ b/src/ReserveMe/ReserveMe.Server/Interfaces/ITableService.cs
@@ -1,0 +1,19 @@
+using Shared.Dtos;
+using Shared.Enums;
+
+namespace ReserveMe.Server.Interfaces
+{
+    public interface ITableService
+    {
+        Task<IEnumerable<TableDto>> GetTablesByVenueAsync(int venueId, bool includeInactive = false);
+        Task<TableDto?> GetTableByIdAsync(int tableId);
+        Task<TableStatisticsDto> GetTableStatisticsAsync(int venueId);
+        Task<TableDto> CreateTableAsync(CreateTableDto dto);
+        Task<TableDto?> UpdateTableAsync(int tableId, UpdateTableDto dto);
+        Task<TableDto?> ChangeTableStatusAsync(int tableId, TableStatus newStatus);
+        Task<TableDto?> ReleaseTableAsync(int tableId);
+        Task<TableDto?> SeatReservationAsync(int tableId);
+        Task<bool> DeleteTableAsync(int tableId);
+        Task<TableDto?> ToggleTableActiveAsync(int tableId);
+    }
+}

--- a/src/ReserveMe/ReserveMe.Server/Program.cs
+++ b/src/ReserveMe/ReserveMe.Server/Program.cs
@@ -7,6 +7,8 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
+using ReserveMe.Server.Interfaces;
+using ReserveMe.Server.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -49,6 +51,8 @@ builder.Services.AddCors(options =>
 });
 
 builder.Services.AddAuthorization();
+
+builder.Services.AddScoped<ITableService, TableService>();
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();

--- a/src/ReserveMe/ReserveMe.Server/Services/TableService.cs
+++ b/src/ReserveMe/ReserveMe.Server/Services/TableService.cs
@@ -1,0 +1,183 @@
+using Microsoft.EntityFrameworkCore;
+using Infrastructure;
+using Domain.Entities;
+using Domain.Enums;
+using Shared.Enums;
+using Shared.Dtos;
+using ReserveMe.Server.Interfaces;
+
+namespace ReserveMe.Server.Services
+{
+    public class TableService : ITableService
+    {
+        private readonly ApplicationDbContext _context;
+
+        public TableService(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<IEnumerable<TableDto>> GetTablesByVenueAsync(int venueId, bool includeInactive = false)
+        {
+            var query = _context.Tables.Where(t => t.VenueId == venueId);
+
+            if (!includeInactive)
+                query = query.Where(t => t.IsActive);
+
+            var tables = await query.OrderBy(t => t.TableNumber).ToListAsync();
+
+            var result = new List<TableDto>();
+            foreach (var table in tables)
+            {
+                var dto = MapToDto(table);
+
+                if (table.Status == TableStatus.Reserved)
+                {
+                    var reservation = await _context.Reservations
+                        .Where(r => r.VenueId == venueId &&
+                                    r.TableNumber == table.TableNumber &&
+                                    r.Status == ReservationStatus.Approved &&
+                                    r.ReservationTime.HasValue &&
+                                    r.ReservationTime.Value.Date == DateTime.Today)
+                        .OrderBy(r => r.ReservationTime)
+                        .FirstOrDefaultAsync();
+
+                    if (reservation != null)
+                    {
+                        dto.CurrentReservationId = reservation.Id;
+                        dto.CustomerName = reservation.ContactName;
+                        dto.CustomerPhone = reservation.ContactPhone;
+                        dto.ReservationTime = reservation.ReservationTime;
+                        dto.GuestCount = reservation.GuestsCount;
+                    }
+                }
+                result.Add(dto);
+            }
+
+            return result;
+        }
+
+        public async Task<TableDto?> GetTableByIdAsync(int tableId)
+        {
+            var table = await _context.Tables.FindAsync(tableId);
+            return table == null ? null : MapToDto(table);
+        }
+
+        public async Task<TableStatisticsDto> GetTableStatisticsAsync(int venueId)
+        {
+            var tables = await _context.Tables.Where(t => t.VenueId == venueId).ToListAsync();
+
+            return new TableStatisticsDto
+            {
+                TotalTables = tables.Count,
+                ActiveTables = tables.Count(t => t.IsActive),
+                AvailableTables = tables.Count(t => t.IsActive && t.Status == TableStatus.Available),
+                OccupiedTables = tables.Count(t => t.IsActive && t.Status == TableStatus.Occupied),
+                ReservedTables = tables.Count(t => t.IsActive && t.Status == TableStatus.Reserved),
+                InactiveTables = tables.Count(t => !t.IsActive)
+            };
+        }
+
+        public async Task<TableDto> CreateTableAsync(CreateTableDto dto)
+        {
+            var exists = await _context.Tables
+                .AnyAsync(t => t.VenueId == dto.VenueId && t.TableNumber == dto.TableNumber);
+
+            if (exists)
+                throw new InvalidOperationException($"Table {dto.TableNumber} already exists.");
+
+            var table = new Table
+            {
+                VenueId = dto.VenueId,
+                TableNumber = dto.TableNumber,
+                Capacity = dto.Capacity,
+                Status = TableStatus.Available,
+                IsActive = true
+            };
+
+            _context.Tables.Add(table);
+            await _context.SaveChangesAsync();
+
+            return MapToDto(table);
+        }
+
+        public async Task<TableDto?> UpdateTableAsync(int tableId, UpdateTableDto dto)
+        {
+            var table = await _context.Tables.FindAsync(tableId);
+            if (table == null) return null;
+
+            if (dto.TableNumber.HasValue)
+                table.TableNumber = dto.TableNumber.Value;
+
+            if (dto.Capacity.HasValue)
+                table.Capacity = dto.Capacity.Value;
+
+            if (dto.IsActive.HasValue)
+                table.IsActive = dto.IsActive.Value;
+
+            await _context.SaveChangesAsync();
+            return MapToDto(table);
+        }
+
+        public async Task<TableDto?> ChangeTableStatusAsync(int tableId, TableStatus newStatus)
+        {
+            var table = await _context.Tables.FindAsync(tableId);
+            if (table == null) return null;
+
+            table.Status = newStatus;
+            await _context.SaveChangesAsync();
+
+            return MapToDto(table);
+        }
+
+        public async Task<TableDto?> ReleaseTableAsync(int tableId)
+        {
+            return await ChangeTableStatusAsync(tableId, TableStatus.Available);
+        }
+
+        public async Task<TableDto?> SeatReservationAsync(int tableId)
+        {
+            var table = await _context.Tables.FindAsync(tableId);
+            if (table == null) return null;
+
+            if (table.Status != TableStatus.Reserved)
+                throw new InvalidOperationException("Table is not reserved.");
+
+            table.Status = TableStatus.Occupied;
+            await _context.SaveChangesAsync();
+
+            return MapToDto(table);
+        }
+
+        public async Task<bool> DeleteTableAsync(int tableId)
+        {
+            var table = await _context.Tables.FindAsync(tableId);
+            if (table == null) return false;
+
+            _context.Tables.Remove(table);
+            await _context.SaveChangesAsync();
+            return true;
+        }
+
+        public async Task<TableDto?> ToggleTableActiveAsync(int tableId)
+        {
+            var table = await _context.Tables.FindAsync(tableId);
+            if (table == null) return null;
+
+            table.IsActive = !table.IsActive;
+            await _context.SaveChangesAsync();
+
+            return MapToDto(table);
+        }
+
+        private static TableDto MapToDto(Table table) => new()
+        {
+            Id = table.Id,
+            VenueId = table.VenueId,
+            TableNumber = table.TableNumber,
+            Capacity = table.Capacity,
+            Status = table.Status,
+            IsActive = table.IsActive
+        };
+    }
+}

--- a/src/ReserveMe/ReserveMe/Pages/Waiter/WaiterTableManagement.razor
+++ b/src/ReserveMe/ReserveMe/Pages/Waiter/WaiterTableManagement.razor
@@ -1,6 +1,7 @@
 @page "/waiter/tables"
 @namespace ReserveMe.Pages.Waiter
-@using ReserveMe.Pages.Owner
+@using Shared.Enums
+@using Shared.Dtos
 
 <PageTitle>Tables - Waiter</PageTitle>
 
@@ -72,52 +73,64 @@
         </div>
     </div>
 
-    @* Tables Grid *@
-    <div class="row g-3">
-        @foreach (var table in FilteredTables)
-        {
-            <div class="col-6 col-sm-4 col-md-3 col-lg-2">
-                <div class="card table-card @GetTableCardClass(table)"
-                     @onclick="() => SelectTable(table)"
-                     style="cursor: pointer;">
-                    <div class="card-body text-center p-3">
-                        <div class="position-relative d-inline-block">
-                            <i class="bi bi-table fs-1" style="color: @GetStatusColor(table.Status);"></i>
-                            @if (table.Status == TableStatus.Reserved && table.ReservationId.HasValue)
+    @* Loading *@
+    @if (_isLoading)
+    {
+        <div class="text-center py-5">
+            <div class="spinner-border text-primary" role="status">
+                <span class="visually-hidden">Loading...</span>
+            </div>
+        </div>
+    }
+    else
+    {
+        @* Tables Grid *@
+        <div class="row g-3">
+            @foreach (var table in FilteredTables)
+            {
+                <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+                    <div class="card table-card @GetTableCardClass(table)"
+                         @onclick="() => SelectTable(table)"
+                         style="cursor: pointer;">
+                        <div class="card-body text-center p-3">
+                            <div class="position-relative d-inline-block">
+                                <i class="bi bi-table fs-1" style="color: @GetStatusColor(table.Status);"></i>
+                                @if (table.Status == TableStatus.Reserved && table.CurrentReservationId.HasValue)
+                                {
+                                    <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-warning">
+                                        <i class="bi bi-calendar-event"></i>
+                                    </span>
+                                }
+                            </div>
+                            <h6 class="mt-2 mb-1">Table #@table.TableNumber</h6>
+                            <span class="badge @GetStatusBadgeClass(table.Status)">
+                                @GetStatusText(table.Status)
+                            </span>
+                            <div class="mt-2 text-muted small">
+                                <i class="bi bi-person"></i> @table.Capacity seats
+                            </div>
+                            @if (!table.IsActive)
                             {
-                                <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-warning">
-                                    <i class="bi bi-calendar-event"></i>
-                                </span>
+                                <span class="badge bg-secondary mt-1">Inactive</span>
                             }
                         </div>
-                        <h6 class="mt-2 mb-1">Table #@table.TableNumber</h6>
-                        <span class="badge @GetStatusBadgeClass(table.Status)">
-                            @GetStatusText(table.Status)
-                        </span>
-                        <div class="mt-2 text-muted small">
-                            <i class="bi bi-person"></i> @table.Capacity seats
-                        </div>
-                        @if (!table.IsActive)
-                        {
-                            <span class="badge bg-secondary mt-1">Inactive</span>
-                        }
                     </div>
                 </div>
-            </div>
-        }
+            }
 
-        @if (!FilteredTables.Any())
-        {
-            <div class="col-12">
-                <div class="card">
-                    <div class="card-body text-center py-5">
-                        <i class="bi bi-table fs-1 text-muted"></i>
-                        <h5 class="mt-3 text-muted">No tables with this status</h5>
+            @if (!FilteredTables.Any())
+            {
+                <div class="col-12">
+                    <div class="card">
+                        <div class="card-body text-center py-5">
+                            <i class="bi bi-table fs-1 text-muted"></i>
+                            <h5 class="mt-3 text-muted">No tables with this status</h5>
+                        </div>
                     </div>
                 </div>
-            </div>
-        }
-    </div>
+            }
+        </div>
+    }
 </div>
 
 @* Details Offcanvas *@
@@ -150,11 +163,11 @@
                         @(_selectedTable.IsActive ? "Yes" : "No")
                     </span>
                 </li>
-                @if (_selectedTable.ReservationId.HasValue)
+                @if (_selectedTable.CurrentReservationId.HasValue)
                 {
                     <li class="list-group-item d-flex justify-content-between">
                         <span><i class="bi bi-calendar-event me-2"></i>Reservation</span>
-                        <strong>#@_selectedTable.ReservationId.Value.ToString().Substring(0, 8)...</strong>
+                        <strong>#@_selectedTable.CurrentReservationId</strong>
                     </li>
                     @if (!string.IsNullOrEmpty(_selectedTable.CustomerName))
                     {
@@ -167,7 +180,7 @@
                     {
                         <li class="list-group-item d-flex justify-content-between">
                             <span><i class="bi bi-clock me-2"></i>Time</span>
-                            <strong>@_selectedTable.ReservationTime.Value.ToString(@"hh\:mm")</strong>
+                            <strong>@_selectedTable.ReservationTime.Value.ToString("HH:mm")</strong>
                         </li>
                     }
                 }
@@ -184,7 +197,7 @@
                 }
                 @if (_selectedTable.Status == TableStatus.Occupied)
                 {
-                    <button class="btn btn-success" @onclick="() => ChangeTableStatus(_selectedTable, TableStatus.Available)">
+                    <button class="btn btn-success" @onclick="() => CancelReservation(_selectedTable)">
                         <i class="bi bi-check-circle me-1"></i> Release Table
                     </button>
                 }

--- a/src/ReserveMe/ReserveMe/Program.cs
+++ b/src/ReserveMe/ReserveMe/Program.cs
@@ -14,7 +14,7 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 
 builder.Services.AddScoped(sp => new HttpClient
 {
-	BaseAddress = new Uri(builder.HostEnvironment.BaseAddress)
+    BaseAddress = new Uri("http://localhost:5272/")
 });
 
 builder.Services.AddBlazoredLocalStorage();

--- a/src/ReserveMe/Shared/Dtos/TableDto.cs
+++ b/src/ReserveMe/Shared/Dtos/TableDto.cs
@@ -1,0 +1,63 @@
+using System.ComponentModel.DataAnnotations;
+using Shared.Enums;
+
+namespace Shared.Dtos
+{
+    public class TableDto
+    {
+        public int Id { get; set; }
+        public int VenueId { get; set; }
+        public int TableNumber { get; set; }
+        public int Capacity { get; set; }
+        public TableStatus Status { get; set; }
+        public bool IsActive { get; set; }
+
+        // Current reservation info
+        public int? CurrentReservationId { get; set; }
+        public string? CustomerName { get; set; }
+        public string? CustomerPhone { get; set; }
+        public DateTime? ReservationTime { get; set; }
+        public int? GuestCount { get; set; }
+    }
+
+    public class CreateTableDto
+    {
+        [Required]
+        public int VenueId { get; set; }
+
+        [Required]
+        [Range(1, 999)]
+        public int TableNumber { get; set; }
+
+        [Required]
+        [Range(1, 50)]
+        public int Capacity { get; set; }
+    }
+
+    public class UpdateTableDto
+    {
+        [Range(1, 999)]
+        public int? TableNumber { get; set; }
+
+        [Range(1, 50)]
+        public int? Capacity { get; set; }
+
+        public bool? IsActive { get; set; }
+    }
+
+    public class ChangeTableStatusDto
+    {
+        [Required]
+        public TableStatus Status { get; set; }
+    }
+
+    public class TableStatisticsDto
+    {
+        public int TotalTables { get; set; }
+        public int ActiveTables { get; set; }
+        public int AvailableTables { get; set; }
+        public int OccupiedTables { get; set; }
+        public int ReservedTables { get; set; }
+        public int InactiveTables { get; set; }
+    }
+}

--- a/src/ReserveMe/Shared/Enums/TableStatus.cs
+++ b/src/ReserveMe/Shared/Enums/TableStatus.cs
@@ -1,0 +1,9 @@
+namespace Shared.Enums
+{
+    public enum TableStatus
+    {
+        Available = 0,
+        Occupied = 1,
+        Reserved = 2
+    }
+}


### PR DESCRIPTION
## What’s added

- Waiter table management page (/waiter/tables)
- Real-time style table overview with statistics (Active tables, Available, Occupied, Reserved)
- Status filter buttons (All, Available, Occupied, Reserved)
- Tables grid with color-coded status icon + status badge
- Reserved indicator badge on table card when a reservation exists
- Table details offcanvas (number, status, capacity, active state + reservation snippet, customer, time)
- Quick actions per status:
  - Available → Mark as occupied
  - Occupied → Release table
  - Reserved → Seat guests / Cancel reservation
     - Active-only visibility for waiter view (inactive tables hidden from the list)
     - Mock table data including reservation info (ReservationId, customer name, reservation time)